### PR TITLE
Add path for /usr/bin/nohup

### DIFF
--- a/deploy/Dockerfile_jenkins
+++ b/deploy/Dockerfile_jenkins
@@ -12,6 +12,6 @@ COPY --from=0 /usr/local/bin/docker-credential-ecr-login /usr/local/bin/docker-c
 COPY --from=0 /kaniko/ssl/certs/ /kaniko/ssl/certs/
 ENV HOME /root
 ENV USER /root
-ENV PATH /bin:/usr/local/bin
+ENV PATH /bin:/usr/bin:/usr/local/bin
 ENV SSL_CERT_DIR=/kaniko/ssl/certs
 ENTRYPOINT ["/kaniko/executor"]


### PR DESCRIPTION
Follow up from jenkinsci/kubernetes-plugin#312

[coreutils contents](https://pkgs.alpinelinux.org/contents?repo=main&page=2&arch=armhf&branch=edge&name=coreutils) show nohup in `/usr/bin` but the PATH does not include that in the docker file
```
ENV PATH /bin:/usr/local/bin
```
Without this change you get
```
[testKanikoExample] Running shell script
/bin/sh: nohup: not found
EXITCODE 127[Pipeline] }
```